### PR TITLE
Add basic To-Do manager example

### DIFF
--- a/tests/test_db_manager.py
+++ b/tests/test_db_manager.py
@@ -1,0 +1,35 @@
+import os
+import unittest
+from todo_app.db_manager import DBManager
+
+
+class TestDBManager(unittest.TestCase):
+    def setUp(self):
+        self.db_file = "test_tasks_notes.db"
+        if os.path.exists(self.db_file):
+            os.remove(self.db_file)
+        self.db = DBManager(self.db_file)
+
+    def tearDown(self):
+        self.db.close()
+        if os.path.exists(self.db_file):
+            os.remove(self.db_file)
+
+    def test_add_and_list_task(self):
+        tid = self.db.add_task("Task 1", "2024-01-01", 1)
+        tasks = self.db.list_tasks()
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0][0], tid)
+        self.assertEqual(tasks[0][1], "Task 1")
+
+    def test_add_and_delete_note(self):
+        nid = self.db.add_note("Note", "content")
+        notes = self.db.list_notes()
+        self.assertEqual(len(notes), 1)
+        self.db.delete_note(nid)
+        notes = self.db.list_notes()
+        self.assertEqual(notes, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/todo_app/README.md
+++ b/todo_app/README.md
@@ -1,0 +1,18 @@
+# To-Do & Notes Manager
+
+A simple two-tab application for managing tasks and notes using Tkinter and SQLite.
+
+## Features
+
+- To-Do tab with task list, add/delete/mark done.
+- Notes tab with note list and editor.
+- Tasks and notes stored in `tasks_notes.db`.
+- Minimal bubble overlay on Windows when the window is minimized showing the number of pending tasks.
+
+## Running
+
+```bash
+python -m todo_app.main
+```
+
+A requirements file is provided with optional dependencies for styling and packaging.

--- a/todo_app/__init__.py
+++ b/todo_app/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['main', 'db_manager']

--- a/todo_app/db_manager.py
+++ b/todo_app/db_manager.py
@@ -1,0 +1,113 @@
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+
+class DBManager:
+    """SQLite database manager for tasks and notes."""
+
+    def __init__(self, db_path: str = "tasks_notes.db"):
+        self.db_path = Path(db_path)
+        self.conn = sqlite3.connect(self.db_path)
+        self.conn.execute("PRAGMA foreign_keys = 1")
+        self.create_tables()
+
+    def create_tables(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tasks(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT NOT NULL,
+                due_date TEXT,
+                priority INTEGER,
+                status TEXT DEFAULT 'pending'
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS notes(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT NOT NULL,
+                content TEXT,
+                last_modified TEXT
+            )
+            """
+        )
+        self.conn.commit()
+
+    # Task methods
+    def add_task(self, title: str, due_date: str | None = None, priority: int = 0) -> int:
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO tasks(title, due_date, priority, status) VALUES(?,?,?,?)",
+            (title, due_date, priority, "pending"),
+        )
+        self.conn.commit()
+        return cur.lastrowid
+
+    def update_task(self, task_id: int, **kwargs) -> None:
+        fields = []
+        values = []
+        for key, value in kwargs.items():
+            if key in {"title", "due_date", "priority", "status"}:
+                fields.append(f"{key} = ?")
+                values.append(value)
+        if not fields:
+            return
+        values.append(task_id)
+        self.conn.execute(
+            f"UPDATE tasks SET {', '.join(fields)} WHERE id = ?", values
+        )
+        self.conn.commit()
+
+    def delete_task(self, task_id: int) -> None:
+        self.conn.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
+        self.conn.commit()
+
+    def list_tasks(self) -> list[sqlite3.Row]:
+        cur = self.conn.cursor()
+        cur.execute(
+            "SELECT id, title, due_date, priority, status FROM tasks ORDER BY id"
+        )
+        return cur.fetchall()
+
+    # Note methods
+    def add_note(self, title: str, content: str = "") -> int:
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO notes(title, content, last_modified) VALUES(?,?,?)",
+            (title, content, datetime.utcnow().isoformat()),
+        )
+        self.conn.commit()
+        return cur.lastrowid
+
+    def update_note(self, note_id: int, **kwargs) -> None:
+        fields = []
+        values = []
+        for key, value in kwargs.items():
+            if key in {"title", "content"}:
+                fields.append(f"{key} = ?")
+                values.append(value)
+        if not fields:
+            return
+        fields.append("last_modified = ?")
+        values.append(datetime.utcnow().isoformat())
+        values.append(note_id)
+        self.conn.execute(
+            f"UPDATE notes SET {', '.join(fields)} WHERE id = ?", values
+        )
+        self.conn.commit()
+
+    def delete_note(self, note_id: int) -> None:
+        self.conn.execute("DELETE FROM notes WHERE id = ?", (note_id,))
+        self.conn.commit()
+
+    def list_notes(self) -> list[sqlite3.Row]:
+        cur = self.conn.cursor()
+        cur.execute("SELECT id, title, content, last_modified FROM notes ORDER BY id")
+        return cur.fetchall()
+
+    def close(self) -> None:
+        self.conn.close()

--- a/todo_app/main.py
+++ b/todo_app/main.py
@@ -1,0 +1,235 @@
+import json
+import tkinter as tk
+from tkinter import ttk, messagebox, filedialog
+from pathlib import Path
+import platform
+from datetime import datetime
+
+from .db_manager import DBManager
+
+
+class TodoApp(tk.Tk):
+    """Main application window."""
+
+    GEOM_FILE = Path(".todo_geometry")
+
+    def __init__(self, db_path: str = "tasks_notes.db"):
+        super().__init__()
+        self.title("To-Do & Notes Manager")
+        self.minsize(800, 600)
+        self.db = DBManager(db_path)
+        self.protocol("WM_DELETE_WINDOW", self.on_close)
+        self._create_widgets()
+        self.bind("<Unmap>", self._on_minimize)
+        self.bind("<Map>", self._on_restore)
+        self.bubble = None
+        if self.GEOM_FILE.exists():
+            self.geometry(self.GEOM_FILE.read_text())
+
+    def _create_widgets(self):
+        self.notebook = ttk.Notebook(self)
+        self.tasks_frame = ttk.Frame(self.notebook)
+        self.notes_frame = ttk.Frame(self.notebook)
+        self.notebook.add(self.tasks_frame, text="To-Do")
+        self.notebook.add(self.notes_frame, text="Notes")
+        self.notebook.pack(fill=tk.BOTH, expand=True)
+        self._init_tasks_tab()
+        self._init_notes_tab()
+
+    # --- Tasks Tab ---
+    def _init_tasks_tab(self):
+        top = ttk.Frame(self.tasks_frame)
+        top.pack(fill=tk.X)
+        add_btn = ttk.Button(top, text="Add", command=self.add_task_dialog)
+        del_btn = ttk.Button(top, text="Delete", command=self.delete_task)
+        done_btn = ttk.Button(top, text="Mark Done", command=self.mark_done)
+        add_btn.pack(side=tk.LEFT, padx=2, pady=2)
+        del_btn.pack(side=tk.LEFT, padx=2, pady=2)
+        done_btn.pack(side=tk.LEFT, padx=2, pady=2)
+
+        self.task_tree = ttk.Treeview(
+            self.tasks_frame,
+            columns=("title", "due", "priority", "status"),
+            show="headings",
+        )
+        for col in ("title", "due", "priority", "status"):
+            self.task_tree.heading(col, text=col.title())
+        self.task_tree.pack(fill=tk.BOTH, expand=True)
+        self.refresh_tasks()
+
+    def refresh_tasks(self):
+        for row in self.task_tree.get_children():
+            self.task_tree.delete(row)
+        for row in self.db.list_tasks():
+            self.task_tree.insert(
+                "",
+                tk.END,
+                iid=row[0],
+                values=(row[1], row[2] or "", row[3], row[4]),
+            )
+
+    def add_task_dialog(self):
+        dlg = tk.Toplevel(self)
+        dlg.title("New Task")
+        ttk.Label(dlg, text="Title").grid(row=0, column=0)
+        title_var = tk.StringVar()
+        ttk.Entry(dlg, textvariable=title_var).grid(row=0, column=1)
+        ttk.Label(dlg, text="Due Date (YYYY-MM-DD)").grid(row=1, column=0)
+        due_var = tk.StringVar()
+        ttk.Entry(dlg, textvariable=due_var).grid(row=1, column=1)
+        ttk.Label(dlg, text="Priority").grid(row=2, column=0)
+        prio_var = tk.IntVar(value=0)
+        ttk.Entry(dlg, textvariable=prio_var).grid(row=2, column=1)
+        ttk.Button(
+            dlg,
+            text="Add",
+            command=lambda: self._add_task_from_dialog(dlg, title_var, due_var, prio_var),
+        ).grid(row=3, column=0, columnspan=2)
+
+    def _add_task_from_dialog(self, dlg, title_var, due_var, prio_var):
+        title = title_var.get().strip()
+        if not title:
+            messagebox.showerror("Error", "Title required")
+            return
+        due = due_var.get().strip() or None
+        self.db.add_task(title, due, prio_var.get())
+        dlg.destroy()
+        self.refresh_tasks()
+        self._update_bubble()
+
+    def delete_task(self):
+        sel = self.task_tree.selection()
+        if not sel:
+            return
+        task_id = int(sel[0])
+        self.db.delete_task(task_id)
+        self.refresh_tasks()
+        self._update_bubble()
+
+    def mark_done(self):
+        sel = self.task_tree.selection()
+        if not sel:
+            return
+        task_id = int(sel[0])
+        self.db.update_task(task_id, status="done")
+        self.refresh_tasks()
+        self._update_bubble()
+
+    # --- Notes Tab ---
+    def _init_notes_tab(self):
+        left = ttk.Frame(self.notes_frame)
+        left.pack(side=tk.LEFT, fill=tk.Y)
+        right = ttk.Frame(self.notes_frame)
+        right.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+        self.notes_list = tk.Listbox(left)
+        self.notes_list.pack(fill=tk.Y, expand=True)
+        btn_frame = ttk.Frame(left)
+        btn_frame.pack(fill=tk.X)
+        ttk.Button(btn_frame, text="Add", command=self.add_note_dialog).pack(side=tk.LEFT)
+        ttk.Button(btn_frame, text="Delete", command=self.delete_note).pack(side=tk.LEFT)
+        self.notes_list.bind("<<ListboxSelect>>", lambda e: self.show_note())
+
+        self.note_text = tk.Text(right, wrap="word")
+        self.note_text.pack(fill=tk.BOTH, expand=True)
+        self.refresh_notes()
+
+    def refresh_notes(self):
+        self.notes_list.delete(0, tk.END)
+        for row in self.db.list_notes():
+            self.notes_list.insert(tk.END, f"{row[0]}: {row[1]}")
+
+    def add_note_dialog(self):
+        dlg = tk.Toplevel(self)
+        dlg.title("New Note")
+        ttk.Label(dlg, text="Title").grid(row=0, column=0)
+        title_var = tk.StringVar()
+        ttk.Entry(dlg, textvariable=title_var).grid(row=0, column=1)
+        ttk.Button(
+            dlg,
+            text="Add",
+            command=lambda: self._add_note_from_dialog(dlg, title_var),
+        ).grid(row=1, column=0, columnspan=2)
+
+    def _add_note_from_dialog(self, dlg, title_var):
+        title = title_var.get().strip()
+        if not title:
+            messagebox.showerror("Error", "Title required")
+            return
+        self.db.add_note(title, "")
+        dlg.destroy()
+        self.refresh_notes()
+
+    def show_note(self):
+        sel = self.notes_list.curselection()
+        if not sel:
+            return
+        idx = int(self.notes_list.get(sel[0]).split(":", 1)[0])
+        note = next((n for n in self.db.list_notes() if n[0] == idx), None)
+        if note:
+            self.note_text.delete("1.0", tk.END)
+            self.note_text.insert("1.0", note[2])
+
+    def delete_note(self):
+        sel = self.notes_list.curselection()
+        if not sel:
+            return
+        idx = int(self.notes_list.get(sel[0]).split(":", 1)[0])
+        self.db.delete_note(idx)
+        self.note_text.delete("1.0", tk.END)
+        self.refresh_notes()
+
+    # --- Bubble overlay ---
+    def _on_minimize(self, event):
+        if self.state() == "iconic" and platform.system() == "Windows":
+            self.show_bubble()
+
+    def _on_restore(self, event):
+        if self.bubble:
+            self.bubble.destroy()
+            self.bubble = None
+
+    def show_bubble(self):
+        if self.bubble:
+            return
+        self.bubble = tk.Toplevel(self)
+        self.bubble.overrideredirect(True)
+        self.bubble.attributes("-topmost", True)
+        frame = ttk.Frame(self.bubble, padding=10)
+        frame.pack()
+        self.bubble_label = ttk.Label(frame, text="")
+        self.bubble_label.pack(side=tk.LEFT)
+        ttk.Button(frame, text="+", command=self.add_task_dialog).pack(side=tk.LEFT)
+        self._update_bubble()
+        self.bubble.update_idletasks()
+        w = self.bubble.winfo_width()
+        h = self.bubble.winfo_height()
+        sw = self.winfo_screenwidth()
+        self.bubble.geometry(f"{w}x{h}+{sw - w - 10}+100")
+        self.bubble.bind("<Button-1>", lambda e: self._restore_from_bubble())
+
+    def _restore_from_bubble(self):
+        self.deiconify()
+        if self.bubble:
+            self.bubble.destroy()
+            self.bubble = None
+
+    def _update_bubble(self):
+        if not self.bubble:
+            return
+        pending = sum(1 for t in self.db.list_tasks() if t[4] != "done")
+        self.bubble_label.config(text=f"Pending: {pending}")
+
+    def on_close(self):
+        self.GEOM_FILE.write_text(self.geometry())
+        self.db.close()
+        self.destroy()
+
+
+def main():
+    app = TodoApp()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/todo_app/requirements.txt
+++ b/todo_app/requirements.txt
@@ -1,0 +1,2 @@
+ttkbootstrap
+pyinstaller

--- a/todo_app/setup.py
+++ b/todo_app/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup
+
+setup(
+    name="todo_app",
+    version="0.1",
+    py_modules=["todo_app.main", "todo_app.db_manager"],
+    install_requires=["ttkbootstrap"],
+)


### PR DESCRIPTION
## Summary
- add simple Tkinter to-do/notes app with SQLite backend
- include basic tests for the DB manager
- document usage and dependencies

## Testing
- `python -m unittest tests/test_db_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_684f678575c08326836603a8d40880de